### PR TITLE
Fix tarball creation, for real :)

### DIFF
--- a/bob/utils.py
+++ b/bob/utils.py
@@ -45,46 +45,8 @@ def pipe(a, b, indent=True):
 
 def archive_tree(dir, archive):
     """Creates a tar.gz archive from a given directory."""
-
-    abspath = os.path.abspath(dir)
-    base_root = None
-    transposed_base = None
-    is_top_level = False
-
     with tarfile.open(archive, 'w:gz') as tar:
-
-        for root, _, files in os.walk(abspath):
-
-            # Mark the first pass as the top-level directory.
-            if is_top_level is None:
-                is_top_level = True
-
-            if not base_root:
-                base_root = root
-
-            # No path at all for the top-level directory.
-            if not is_top_level:
-                transposed_base = root[len(base_root)+1:]
-            else:
-                transposed_base = ''
-
-
-            for file in files:
-
-                standard_path = os.path.join(root, file)
-
-                if not transposed_base:
-                    transposed_path = file
-                else:
-                    transposed_path = os.path.join(transposed_base, file)
-
-                # Add the file to the archive, with the proper transposed path.
-                tar.add(standard_path, arcname=transposed_path)
-
-
-            # Close out the top-level directory marker.
-            is_top_level = False
-
+        tar.add(dir, arcname=os.path.basename(dir))
 
 def extract_tree(archive, dir):
     """Extract tar.gz archive to a given directory."""

--- a/bob/utils.py
+++ b/bob/utils.py
@@ -46,7 +46,9 @@ def pipe(a, b, indent=True):
 def archive_tree(dir, archive):
     """Creates a tar.gz archive from a given directory."""
     with tarfile.open(archive, 'w:gz') as tar:
-        tar.add(dir, arcname=os.path.basename(dir))
+        # do not tar.add(dir) with empty arcname, that will create a "/" entry and tar will complain when extracting
+        for item in os.listdir(dir):
+            tar.add(dir+"/"+item, arcname=item)
 
 def extract_tree(archive, dir):
     """Extract tar.gz archive to a given directory."""

--- a/bob/utils.py
+++ b/bob/utils.py
@@ -48,6 +48,7 @@ def archive_tree(dir, archive):
 
     abspath = os.path.abspath(dir)
     base_root = None
+    transposed_base = None
     is_top_level = False
 
     with tarfile.open(archive, 'w:gz') as tar:
@@ -61,19 +62,25 @@ def archive_tree(dir, archive):
             if not base_root:
                 base_root = root
 
-            transposed_base = root[len(base_root)+1:]
+            # No path at all for the top-level directory.
+            if not is_top_level:
+                transposed_base = root[len(base_root)+1:]
+            else:
+                transposed_base = ''
+
 
             for file in files:
 
                 standard_path = os.path.join(root, file)
 
-                if is_top_level:
+                if not transposed_base:
                     transposed_path = file
                 else:
                     transposed_path = os.path.join(transposed_base, file)
 
                 # Add the file to the archive, with the proper transposed path.
                 tar.add(standard_path, arcname=transposed_path)
+
 
             # Close out the top-level directory marker.
             is_top_level = False

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ deps = [
 
 setup(
     name='bob-builder',
-    version='0.0.5',
+    version='0.0.6',
     install_requires=deps,
     description='Binary Build Toolkit.',
     # long_description='Meh.',/


### PR DESCRIPTION
The recent change caused empty folders to be discarded.

I looked into the issue again. The old `os.path.basename` call returned an empty string only if `dir` had a trailing slash. Otherwise, it would return the dir name. So this was a bit brittle, because depending on whether or not someone had a trailing slash in the "Build Dir" comment at the top of their file, they'd get different results.

Passing an empty string as `arcname` always causes the empty entry in the tarball. This seems to be related to how `arcname` is passed through a `realpath` call.

The fix, then, is to simply iterate over the top level of the given directory, and add those entries individually (can be files or dirs). Much simpler code, too :)
