### PR TITLE
Use sys.exit and fix SIGINT exit code

### DIFF
--- a/bob/cli.py
+++ b/bob/cli.py
@@ -13,6 +13,7 @@ Configuration:
     Environment Variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET, S3_PREFIX (optional)
 """
 import os
+import sys
 
 from docopt import docopt
 from .models import Formula
@@ -27,7 +28,7 @@ def build(formula):
         assert f.exists
     except AssertionError:
         print 'Formula {} doesn\'t appear to exist.'.format(formula)
-        exit(1)
+        sys.exit(1)
 
     # CLI lies ahead.
     f.build()

--- a/bob/cli.py
+++ b/bob/cli.py
@@ -73,3 +73,4 @@ def dispatch():
         main()
     except KeyboardInterrupt:
         print 'ool.'
+        sys.exit(130)

--- a/bob/models.py
+++ b/bob/models.py
@@ -99,7 +99,7 @@ class Formula(object):
                     print
                     print 'ERROR: Archive {} does not exist.'.format(key_name)
                     print '    Please deploy it to continue.'
-                    exit(1)
+                    sys.exit(1)
 
                 # Grab the Dep from S3, download it to a temp file.
                 archive = mkstemp()[1]
@@ -129,7 +129,7 @@ class Formula(object):
         if p.returncode != 0:
             print
             print 'ERROR: An error occurred.'
-            exit(1)
+            sys.exit(1)
 
 
     def archive(self):
@@ -152,7 +152,7 @@ class Formula(object):
             if not allow_overwrite:
                 print 'ERROR: Archive {} already exists.'.format(key_name)
                 print '    Use the --overwrite flag to continue.'
-                exit(1)
+                sys.exit(1)
         else:
             key = bucket.new_key(key_name)
 


### PR DESCRIPTION
Change `exit()` to `sys.exit()`: https://docs.python.org/2/library/constants.html#constants-added-by-the-site-module:

> The `site` module (which is imported automatically during startup, except if the `-S` command-line option is given) adds several constants to the built-in namespace. They are useful for the interactive interpreter shell and should not be used in programs.

Also (more importantly) exits with status 130 when a keyboard interrupt is caught. Programs exiting in reaction to a signal must exit with status 128+`$SIGNAL`, in this case 128+`INT` = 128+2 = 130.

Otherwise, the parent program that calls `bob` sees an exit status of 0 when the users `Ctrl+C`-s during the `bob` run, and, instead of noticing the failure (due to a conditional, or `set -e`), it continues with the next statement after the invocation of `bob`.
