### PR TITLE
Improve UX when AWS credentials are not found or are for another account

### DIFF
--- a/bob/cli.py
+++ b/bob/cli.py
@@ -12,10 +12,13 @@ Options:
 Configuration:
     Environment Variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET, S3_PREFIX (optional), UPSTREAM_S3_BUCKET (optional), UPSTREAM_S3_PREFIX (optional)
 """
+from __future__ import print_function
+
 import sys
 
 from docopt import docopt
 from .models import Formula
+from .utils import print_stderr
 
 
 
@@ -26,7 +29,7 @@ def build(formula):
     try:
         assert f.exists
     except AssertionError:
-        print 'Formula {} doesn\'t appear to exist.'.format(formula)
+        print_stderr("Formula {} doesn't exist.".format(formula))
         sys.exit(1)
 
     # CLI lies ahead.
@@ -42,10 +45,10 @@ def build(formula):
 def deploy(formula, overwrite):
     f = build(formula)
 
-    print 'Archiving.'
+    print('Archiving.')
     f.archive()
 
-    print 'Deploying.'
+    print('Deploying.')
     f.deploy(allow_overwrite=overwrite)
 
 
@@ -71,5 +74,5 @@ def dispatch():
     try:
         main()
     except KeyboardInterrupt:
-        print 'ool.'
+        print('ool.')
         sys.exit(130)

--- a/bob/models.py
+++ b/bob/models.py
@@ -38,6 +38,10 @@ class Formula(object):
         self.path = path
         self.archived_path = None
 
+        if not S3_BUCKET:
+            print_stderr('The environment variable S3_BUCKET must be set to the bucket name.')
+            sys.exit(1)
+
         s3 = S3ConnectionHandler()
         self.bucket = s3.get_bucket(S3_BUCKET)
         self.upstream = s3.get_bucket(UPSTREAM_S3_BUCKET) if UPSTREAM_S3_BUCKET else None

--- a/bob/models.py
+++ b/bob/models.py
@@ -145,6 +145,7 @@ class Formula(object):
             print_stderr('Formula exited with return code {}.'.format(p.returncode))
             sys.exit(1)
 
+        print('\nBuild complete: {}'.format(self.build_path))
 
     def archive(self):
         """Archives the build directory as a tar.gz."""
@@ -174,6 +175,11 @@ class Formula(object):
         else:
             key = self.bucket.new_key(key_name)
 
+        url = key.generate_url(0, query_auth=False)
+        print('Uploading to: {}'.format(url))
+
         # Upload the archive, set permissions.
         key.set_contents_from_filename(self.archived_path)
         key.set_acl('public-read')
+
+        print('Upload complete!')

--- a/bob/utils.py
+++ b/bob/utils.py
@@ -1,12 +1,19 @@
 # -*- coding: utf-8 -*-
 
+from __future__ import print_function
+
 import errno
 import os
+import sys
 import tarfile
 from subprocess import Popen, PIPE, STDOUT
 
 import boto
 from boto.exception import NoAuthHandlerFound, S3ResponseError
+
+
+def print_stderr(message, prefix='ERROR'):
+    print('\n{}: {}\n'.format(prefix, message), file=sys.stderr)
 
 
 def iter_marker_lines(marker, formula, strip=True):
@@ -78,7 +85,8 @@ class S3ConnectionHandler(object):
         try:
             self.s3 = boto.connect_s3()
         except NoAuthHandlerFound:
-            print 'No AWS credentials found. Requests will be made without authentication.'
+            print_stderr('No AWS credentials found. Requests will be made without authentication.',
+                         prefix='WARNING')
             self.s3 = boto.connect_s3(anon=True)
 
     def get_bucket(self, name):
@@ -86,8 +94,8 @@ class S3ConnectionHandler(object):
             return self.s3.get_bucket(name)
         except S3ResponseError as e:
             if e.status == 403 and not self.s3.anon:
-                print ('Access denied for bucket "{0}" using found credentials. '
-                       'Retrying as an anonymous user.'.format(name))
+                print('Access denied for bucket "{}" using found credentials. '
+                      'Retrying as an anonymous user.'.format(name))
                 if not hasattr(self, 's3_anon'):
                     self.s3_anon = boto.connect_s3(anon=True)
                 return self.s3_anon.get_bucket(name)


### PR DESCRIPTION
**1) Move S3 connection handling to its own class**
This means that the main bucket also benefits from the access denied `anon=True` fall-back previously only used for the upstream bucket. This helps with the case where AWS credentials are found, but are for an account unrelated to either bucket.

Since the main bucket can now fall back to anonymous mode, a check has been added to the deploy command to improve the UX.

Fixes https://github.com/kennethreitz/bob-builder/issues/26#issuecomment-301058112.

**2) Support no AWS credentials being found in the environment**
This allows the build command to be used with public buckets even if the user doesn't have their own AWS credentials.

Fixes #26.

**3) Defer S3 connections until Formula instantiation**
This prevents unnecessary connections to S3 or resultant error messages when running `bob --help`.

Fixes #27.

**4) Make errors output to stderr**
Using `print_function` is the cleanest option out of those on:
https://stackoverflow.com/questions/5574702/how-to-print-to-stderr-in-python

**5) Fail gracefully if S3_BUCKET is not set**
Previously this raised with the unclear:
`TypeError: cannot concatenate 'str' and 'NoneType' objects`

**6) Print build directory & upload URL during build/deploy**
Previously only the temporary build directory was output, not the final build output location.

The upload URL is generated using:
http://boto.cloudhackers.com/en/latest/ref/s3.html#boto.s3.key.Key.generate_url

Fixes #10.