### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+*.py[cod]
+*.egg-info/
+build/
+dist/


### PR DESCRIPTION
This covers files generated by `pip install -e .` and `./setup.py sdist bdist_wheel`.