### PR TITLE
Use clearer file and directory names for build output

### DIFF
--- a/bob/models.py
+++ b/bob/models.py
@@ -124,7 +124,7 @@ class Formula(object):
                     sys.exit(1)
 
                 # Grab the Dep from S3, download it to a temp file.
-                archive = mkstemp()[1]
+                archive = mkstemp(prefix='bob-dep-', suffix='.tar.gz')[1]
                 key.get_contents_to_filename(archive)
 
                 # Extract the Dep to the appropriate location.
@@ -139,7 +139,7 @@ class Formula(object):
         self.resolve_deps()
 
         # Temporary directory where work will be carried out, because of David.
-        cwd_path = mkdtemp(prefix='bob')
+        cwd_path = mkdtemp(prefix='bob-')
 
         print 'Building formula {} in {}:'.format(self.path, cwd_path)
 
@@ -158,7 +158,7 @@ class Formula(object):
 
     def archive(self):
         """Archives the build directory as a tar.gz."""
-        archive = mkstemp()[1]
+        archive = mkstemp(prefix='bob-build-', suffix='.tar.gz')[1]
         archive_tree(self.build_path, archive)
 
         print archive


### PR DESCRIPTION
This makes it easier to differentiate between the archives for dependencies and that of the final build output by bob when sifting through `/tmp/`. The archive type is now also apparent when reading the console output.

Before:
```
Building formula foo in /tmp/bobrmyuSG:
    ...
Archiving.
/tmp/tmp4JUwdj
Deploying.
...
```

After (when combined with #28):
```
Building formula foo in /tmp/bob-rmyuSG:
    ...
Archiving.
Created: /tmp/bob-build-tmp4JUwdj.tar.gz
Deploying.
...
```