### PR TITLE
execute build formulae through shell

### DIFF
--- a/bob/models.py
+++ b/bob/models.py
@@ -135,8 +135,7 @@ class Formula(object):
         print('Building formula {} in {}:\n'.format(self.path, cwd_path))
 
         # Execute the formula script.
-        cmd = [self.full_path, self.build_path]
-        p = process(cmd, cwd=cwd_path)
+        p = process(["/usr/bin/env", "bash", "--", self.full_path, self.build_path], cwd=cwd_path)
 
         pipe(p.stdout, sys.stdout, indent=True)
         p.wait()


### PR DESCRIPTION
this prevents the need for chmod +x on formulae

fixes #35