### PR TITLE
update so override_path checks for None

### DIFF
--- a/bob/cli.py
+++ b/bob/cli.py
@@ -22,7 +22,7 @@ from .models import Formula
 from .utils import print_stderr
 
 
-def build(formula, name):
+def build(formula, name=None):
     f = Formula(path=formula, override_path=name)
 
     try:

--- a/bob/models.py
+++ b/bob/models.py
@@ -137,7 +137,7 @@ class Formula(object):
 
         # Execute the formula script.
         args = ["/usr/bin/env", "bash", "--", self.full_path, self.build_path]
-        if self.override_path:
+        if self.override_path != None:
             args.append(self.override_path)
 
         p = process(args, cwd=cwd_path)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ deps = [
 
 setup(
     name='bob-builder',
-    version='0.0.16',
+    version='0.0.17',
     install_requires=deps,
     description='Binary Build Toolkit.',
     # long_description='Meh.',/


### PR DESCRIPTION
After updating the name, it became clear that None behavior for override_path was buggy. Override_name should only be used if not None, so making that behavior explicit.