### PR TITLE
Cleanup for Python 3 compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,3 @@ script:
   # TODO: Replace with an actual test suite:
   # https://github.com/kennethreitz/bob-builder/issues/31
   - bob --help
-matrix:
-  allow_failures:
-    - python: "3.4"
-    - python: "3.5"
-    - python: "3.6"
-  fast_finish: true

--- a/bob/cli.py
+++ b/bob/cli.py
@@ -13,8 +13,6 @@ Options:
 Configuration:
     Environment Variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET, S3_PREFIX (optional), UPSTREAM_S3_BUCKET (optional), UPSTREAM_S3_PREFIX (optional)
 """
-from __future__ import print_function
-
 import sys
 
 from docopt import docopt
@@ -28,7 +26,7 @@ def build(formula, name=None):
     try:
         assert f.exists
     except AssertionError:
-        print_stderr("Formula {} doesn't exist.".format(formula))
+        print_stderr("Formula {} doesn't exist.".format(formula), title='ERROR')
         sys.exit(1)
 
     # CLI lies ahead.
@@ -40,10 +38,10 @@ def build(formula, name=None):
 def deploy(formula, overwrite, name):
     f = build(formula, name)
 
-    print('Archiving.')
+    print_stderr('Archiving.')
     f.archive()
 
-    print('Deploying.')
+    print_stderr('Deploying.')
     f.deploy(allow_overwrite=overwrite)
 
 

--- a/bob/cli.py
+++ b/bob/cli.py
@@ -13,6 +13,8 @@ Options:
 Configuration:
     Environment Variables: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, S3_BUCKET, S3_PREFIX (optional), UPSTREAM_S3_BUCKET (optional), UPSTREAM_S3_PREFIX (optional)
 """
+import os
+import signal
 import sys
 
 from docopt import docopt
@@ -61,9 +63,18 @@ def main():
         deploy(formula, overwrite=do_overwrite, name=do_name)
 
 
+def sigint_handler(signo, frame):
+    # when receiving a signal, a process must kill itself using the same signal
+    # sys.exit()ing 0, 1, 130, whatever will not signal to the calling program that we terminated in response to the signal
+    # best example: `for f in a b c; do bob deploy $f; done`, hitting Ctrl+C should interrupt Bob and stop the bash loop
+    # that's only possible if Bash knows that we exited in response to Ctrl+C (=SIGINT), then it'll also terminate the loop
+    # bash will report the exit status as 128+$signal, so 130 for SIGINT, but sys.exit(130) does not to the same thing - the value of 130 is simply bash's representation
+    # killing ourselves with the signal number that we are aborting in response to does all this correctly, and bash will see the right WIFSIGNALED() status of our program, not WIFEXITED()
+    
+    # and finally, before we send ourselves the right signal, we must first restore the handler for it to the default
+    signal.signal(signo, signal.SIG_DFL)
+    os.kill(os.getpid(), signo)
+
 def dispatch():
-    try:
-        main()
-    except KeyboardInterrupt:
-        print('ool.')
-        sys.exit(130)
+    signal.signal(signal.SIGINT, sigint_handler)
+    main()

--- a/bob/utils.py
+++ b/bob/utils.py
@@ -6,7 +6,6 @@ import errno
 import os
 import sys
 import tarfile
-from subprocess import Popen, PIPE, STDOUT
 
 import boto
 from boto.exception import NoAuthHandlerFound, S3ResponseError
@@ -40,23 +39,6 @@ def mkdir_p(path):
             pass
         else:
             raise
-
-
-def process(cmd, cwd=None):
-    """A simple wrapper around the subprocess module; stderr is redirected to stdout."""
-    p = Popen(cmd, cwd=cwd, shell=False, stdout=PIPE, stderr=STDOUT)
-    return p
-
-
-def pipe(a, b, indent=True):
-    """Pipes stream A to stream B, with optional indentation."""
-
-    for line in iter(a.readline, b''):
-
-        if indent:
-            b.write('    ')
-
-        b.write(line)
 
 
 def archive_tree(dir, archive):

--- a/bob/utils.py
+++ b/bob/utils.py
@@ -13,8 +13,8 @@ from boto.exception import NoAuthHandlerFound, S3ResponseError
 from distutils.version import LooseVersion
 from fnmatch import fnmatchcase
 
-def print_stderr(message, prefix='ERROR'):
-    print('\n{}: {}\n'.format(prefix, message), file=sys.stderr)
+def print_stderr(message='', title=''):
+    print(('\n{1}: {0}\n' if title else '{0}').format(message, title), file=sys.stderr)
 
 
 def iter_marker_lines(marker, formula, strip=True):
@@ -86,7 +86,7 @@ class S3ConnectionHandler(object):
             self.s3 = boto.connect_s3()
         except NoAuthHandlerFound:
             print_stderr('No AWS credentials found. Requests will be made without authentication.',
-                         prefix='WARNING')
+                         title='WARNING')
             self.s3 = boto.connect_s3(anon=True)
 
     def get_bucket(self, name):
@@ -94,8 +94,8 @@ class S3ConnectionHandler(object):
             return self.s3.get_bucket(name)
         except S3ResponseError as e:
             if e.status == 403 and not self.s3.anon:
-                print('Access denied for bucket "{}" using found credentials. '
-                      'Retrying as an anonymous user.'.format(name))
+                print_stderr('Access denied for bucket "{}" using found credentials. '
+                             'Retrying as an anonymous user.'.format(name), title='NOTICE')
                 if not hasattr(self, 's3_anon'):
                     self.s3_anon = boto.connect_s3(anon=True)
                 return self.s3_anon.get_bucket(name)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ deps = [
 
 setup(
     name='bob-builder',
-    version='0.0.17',
+    version='0.0.18',
     install_requires=deps,
     description='Binary Build Toolkit.',
     # long_description='Meh.',/


### PR DESCRIPTION
This PR contains three changes:

1. remove the whole subprocess output piping business, since that had issues with text vs binary on Python 3, and is unnecessary (output is now auto-sent to the parent stdout) - as a bonus, there no longer is any buffering, which means e.g. `curl` status output is now "live", and not just printed when there's finally a newline (like with the line buffering before)
1. move all informational output from Bob itself to stderr, so that one can e.g. `bob build foobar | tee foobar.build.log`, with stdout containing only the output from the formula
1. fix Ctrl+C handling (programs reacting to a signal must kill themselves using that same signal, not exit with a status code) so that e.g. a bash loop of `bob` invocations can be aborted

More details in each commit message.

Fixes #34.