### PR TITLE
Remove boto 'set_acl' call after upload

### DIFF
--- a/bob/models.py
+++ b/bob/models.py
@@ -192,6 +192,5 @@ class Formula(object):
 
         # Upload the archive, set permissions.
         key.set_contents_from_filename(self.archived_path)
-        key.set_acl('public-read')
 
         print_stderr('Upload complete!')


### PR DESCRIPTION
Since it causes access denied errors when the IAM user does not have `PutObjectAcl` permissions for the S3 bucket, preventing the use of a more locked down IAM user for deployment.

It seems preferable to leave the bucket ACLs to the bucket owner, and for `bob deploy` to only upload the file.

Closes [W-8134681](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07B0000008g2DuIAI/view).