### PR TITLE
Python 3.12 compatibility

### DIFF
--- a/bob/utils.py
+++ b/bob/utils.py
@@ -12,8 +12,8 @@ from botocore import UNSIGNED
 from botocore.config import Config
 from botocore.exceptions import ClientError, NoCredentialsError
 
-from distutils.version import LooseVersion
 from fnmatch import fnmatchcase
+from natsort import natsorted
 
 from collections import namedtuple
 
@@ -97,8 +97,9 @@ def get_with_wildcard(bucket, name):
     
     firstparts = bucket.objects.filter(Prefix=parts[0]) # use anything before "*" as the prefix for S3 listing
     matches = [i for i in firstparts if fnmatchcase(i.key, name)] # fnmatch entire name with wildcard against found keys in S3 - prefix for "dep-1.2.*.tar.gz" was "dep-1.2", but there might be a "dep-1.2.3.sig" or whatnot
+    # natsorted will sort correctly by version parts, even if the element is something like "dep-1.2.3.tar.gz"
     try:
-        return sorted(matches, key=lambda dep: LooseVersion(dep.key)).pop().Object()
+        return natsorted(matches, key=lambda dep: dep.key).pop().Object()
     except IndexError:
         # list was empty
         return None

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ deps = [
 
 setup(
     name='bob-builder',
-    version='0.0.19',
+    version='0.0.20',
     install_requires=deps,
     description='Binary Build Toolkit.',
     # long_description='Meh.',/

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from setuptools import setup
 deps = [
     'boto3',
     'docopt',
+    'natsort',
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@
 from setuptools import setup
 
 deps = [
-    'boto',
+    'boto3',
     'docopt',
 ]
 


### PR DESCRIPTION
Since the old Boto v2 [is not compatible with Python 3.12](https://github.com/boto/boto/issues/3951), we have to move to Boto v3, which necessitated some rewiring of things as the two are quite different conceptually.

[GUS-W-15794831](https://gus.lightning.force.com/a07EE00001rlZLcYAM)